### PR TITLE
Bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "svelte-app",
+  "name": "tab-locker",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/public/background.js
+++ b/public/background.js
@@ -1,4 +1,11 @@
 let lockers = { 1: { header: '', sections: 0 }, 2: { header: '', sections: 0 }, 3: { header: '', sections: 0}, 4: { header: '', sections: 0 }, 5: { header: '', sections: 0 } }
-chrome.runtime.onInstalled.addListener(function() {
-   chrome.storage.sync.set({ tabLockers: lockers })
+
+chrome.runtime.onInstalled.addListener(function({reason}) {
+   if(reason === "install") {
+      chrome.storage.sync.get("tabLockers", ({tabLockers}) => { 
+         if(!tabLockers) {
+            chrome.storage.sync.set({ tabLockers: lockers })
+         }
+      })
+   }
 });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -85,7 +85,7 @@ function initTabList() {
 //Lifecycle methods
 onMount(() => {
 	chrome.storage.sync.get("tabLockers", ({tabLockers}) => { 
-		lockers = tabLockers
+		lockers = tabLockers || lockers
 		initTabList()
 	})
 })

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -140,13 +140,13 @@ onMount(() => {
 	#locker-container {
 		list-style: none;
 		padding: 0;
-		width: 12rem;
+		width: 14rem;
 	}
 	.lockers {
-		max-height: 4.5em;
+		max-height: 7em;
 		text-align: center;
-    padding: 0.25rem;
-    margin: 0.25rem;
+		padding: 0.25rem;
+		margin: 0.25rem;
 		border: 2px solid black;
 		background-color: #4d4855;
 		background-image: linear-gradient(192deg, #4d4855 0%, #000000 74%);
@@ -158,6 +158,7 @@ onMount(() => {
 	}
 	.locker-name {
 		color: #fff;
+		font-size: 14px;
 		margin: 5px;
 		text-shadow: 0 0 5px #fff, 0 0 10px #fff, 0 0 15px #0073e64f, 0 0 20px #0073e64f, 0 0 25px #0073e64f, 0 0 30px #0073e64f, 0 0 35px #0073e64f;
 	}


### PR DESCRIPTION
fix: individual slot spacing with the additional width of locker container and max-height of each locker
fix: locker reference being reset on chrome update by checking if the reason the method is being called is that it's being installed for the first time and that the reference doesn't already exist
add: guard against missing tabLockers reference in chrome storage